### PR TITLE
fix: use pull_request_target for fork PR access to org secrets

### DIFF
--- a/.github/workflows/build-and-run-example-project.yml
+++ b/.github/workflows/build-and-run-example-project.yml
@@ -1,7 +1,7 @@
 name: Build and Run Example Project
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
     paths:
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK 8
         uses: actions/setup-java@v5


### PR DESCRIPTION
- Change trigger from pull_request to pull_request_target so fork PRs can access ORG_CHECKOUT_TOKEN for cross-repo checkout
- Add explicit ref to checkout PR head SHA instead of base branch